### PR TITLE
Replace absolute resource paths with relative (fixes compilation)

### DIFF
--- a/src/resource.rc
+++ b/src/resource.rc
@@ -334,9 +334,9 @@ IDI_TYPING_FRAME2_2K    ICON                    "../res/icon_typing_f2_2k.ico"
 
 IDI_TYPING_FRAME3_2K    ICON                    "../res/icon_typing_f3_2k.ico"
 
-IDI_WAIT                ICON                    "C:\\DiscordMessenger\\dm\\res\\icon_wait.ico"
+IDI_WAIT                ICON                    "../res/icon_wait.ico"
 
-IDI_IMAGE_ERROR         ICON                    "C:\\DiscordMessenger\\dm\\res\\icon_image_error.ico"
+IDI_IMAGE_ERROR         ICON                    "../res/icon_image_error.ico"
 
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Should be self-descriptive.
Absolute paths prevented project from compiling locally on a different machine.
With provided fixes everything builds as expected without errors.