### PR TITLE
Improve Protobuf handling and the settings manager

### DIFF
--- a/deps/protobuf/Protobuf.hpp
+++ b/deps/protobuf/Protobuf.hpp
@@ -1236,6 +1236,17 @@ namespace Protobuf
 		uint32_t m_value;
 	};
 
+
+	/// <summary>
+	/// Decodes a protobuf varint from the given buffer.
+	/// </summary>
+	/// <param name="data">Pointer to the raw buffer (char*).</param>
+	/// <param name="offset">Reference to current offset in buffer (advanced on success).</param>
+	/// <param name="size">Total size of buffer.</param>
+	/// <returns>
+	/// On success, returns the decoded 64-bit value.
+	/// On failure, returns an ErrorOr with error code (e.g., OutOfBounds, VarIntTooBig).
+	/// </returns>
 	static ErrorOr<uint64_t> DecodeVarInt(const char* data, size_t& offset, size_t size)
 	{
 		const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data);
@@ -1265,7 +1276,17 @@ namespace Protobuf
 		return ErrorOr<uint64_t>::success(result);
 	}
 
-	/// Decode a buffer into an ObjectBaseMessage using optional hints.
+	/// <summary>
+	/// Decodes a protobuf-encoded block (message) into the given ObjectBaseMessage.
+	/// </summary>
+	/// <param name="data">Pointer to raw buffer (char*).</param>
+	/// <param name="sz">Size of buffer in bytes.</param>
+	/// <param name="block">Destination ObjectBaseMessage that will receive decoded objects.</param>
+	/// <param name="pHint">Optional DecodeHint to guide how fields are interpreted.</param>
+	/// <returns>
+	/// Result::success() if decoding was successful,
+	/// or Result::failure(ErrorCode) if an error occurred (e.g., OutOfBounds, UnknownTag).
+	/// </returns>
 	static Result<ErrorCode> DecodeBlock(const char* data, size_t sz, ObjectBaseMessage* block, DecodeHint* pHint = nullptr)
 	{
 #ifdef DISABLE_PROTOBUF
@@ -1451,6 +1472,16 @@ namespace Protobuf
 		return Result<ErrorCode>::success();
 	}
 
+	/// <summary>
+	/// Convenience overload of DecodeBlock taking a uint8_t* buffer.
+	/// </summary>
+	/// <param name="data">Pointer to raw buffer (uint8_t*).</param>
+	/// <param name="sz">Size of buffer in bytes.</param>
+	/// <param name="block">Destination ObjectBaseMessage that will receive decoded objects.</param>
+	/// <returns>
+	/// Result::success() if decoding was successful,
+	/// or Result::failure(ErrorCode) if an error occurred.
+	/// </returns>
 	static Result<ErrorCode> DecodeBlock(const uint8_t* data, size_t sz, ObjectBaseMessage* block)
 	{
 		return DecodeBlock(reinterpret_cast<const char*>(data), sz, block);

--- a/deps/protobuf/Protobuf.hpp
+++ b/deps/protobuf/Protobuf.hpp
@@ -14,7 +14,7 @@
 
 //#define DISABLE_PROTOBUF
 
-#define returnIfNonNull(r) do { auto __ = (r); if (__ != 0) return __; } while (0)
+#define returnIfNonNull(r) do { auto __ = (r); if (__ != decltype(r){}) return __; } while (0)
 
 namespace Protobuf
 {

--- a/deps/protobuf/Protobuf.hpp
+++ b/deps/protobuf/Protobuf.hpp
@@ -265,41 +265,24 @@ namespace Protobuf
 	/// <summary>
 	/// Combines a field number and wire tag into a single protobuf key.
 	/// </summary>
+	/// <param name="fieldNumber">The field number.</param>
+	/// <param name="tag">The wire tag.</param>
 	constexpr uint64_t CombineFieldNumberAndTag(FieldNumber fieldNumber, Tag tag) noexcept
 	{
 		return (fieldNumber << 3) | static_cast<uint64_t>(tag);
 	}
-
-	static constexpr uint8_t MSB = 0x80;
-	static constexpr uint8_t MSBALL = ~0x7F;
-
-	static constexpr uint64_t N1 = 1ULL << 7;
-	static constexpr uint64_t N2 = 1ULL << 14;
-	static constexpr uint64_t N3 = 1ULL << 21;
-	static constexpr uint64_t N4 = 1ULL << 28;
-	static constexpr uint64_t N5 = 1ULL << 35;
-	static constexpr uint64_t N6 = 1ULL << 42;
-	static constexpr uint64_t N7 = 1ULL << 49;
-	static constexpr uint64_t N8 = 1ULL << 56;
-	static constexpr uint64_t N9 = 1ULL << 63;
 
 	/// <summary>
 	/// Computes the number of bytes needed to encode a 64-bit unsigned integer as a protobuf varint.
 	/// </summary>
 	static size_t GetVarIntSize(uint64_t n) noexcept
 	{
-		return (
-			n < N1 ? 1
-			: n < N2 ? 2
-			: n < N3 ? 3
-			: n < N4 ? 4
-			: n < N5 ? 5
-			: n < N6 ? 6
-			: n < N7 ? 7
-			: n < N8 ? 8
-			: n < N9 ? 9
-			: 10
-			);
+		size_t bytes = 1;
+		while (n >= 0x80) {
+			n >>= 7;
+			++bytes;
+		}
+		return bytes;
 	}
 
 	/// <summary>

--- a/src/discord/SettingsManager.cpp
+++ b/src/discord/SettingsManager.cpp
@@ -267,12 +267,12 @@ std::vector<Snowflake> SettingsManager::GetGuildFolders()
 		return v;
 	}
 	auto items = pgfRoot->GetFieldObjects(1);
-	if (!items) {
+	if (items.empty()) {
 		DbgPrintF("Failed to fetch guild folder items.");
 		return v;
 	}
 
-	for (auto& item : *items)
+	for (auto& item : items)
 	{
 		auto pBytesBase = item->GetFieldObject(Settings::GuildFolders::Item::FIELD_GUILD_IDS);
 
@@ -314,12 +314,12 @@ void SettingsManager::GetGuildFoldersEx(std::map<Snowflake, std::string>& folder
 		return;
 	}
 	auto items = pgfRoot->GetFieldObjects(Settings::GuildFolders::FIELD_ITEMS);
-	if (!items) {
+	if (items.empty()) {
 		DbgPrintF("Failed to fetch guild folder items.");
 		return;
 	}
 
-	for (auto& item : *items)
+	for (auto& item : items)
 	{
 		// note: I don't understand why this isn't just the fixed64/varint
 		Snowflake folderId = 0;

--- a/src/discord/SettingsManager.hpp
+++ b/src/discord/SettingsManager.hpp
@@ -141,7 +141,7 @@ public: // SETTINGS
 private:
 	Protobuf::DecodeHint* CreateHint();
 
-	Protobuf::ObjectBaseMessage* m_pSettingsMessage = nullptr;
+	std::unique_ptr<Protobuf::ObjectBaseMessage> m_pSettingsMessage = nullptr;
 };
 
 SettingsManager* GetSettingsManager();


### PR DESCRIPTION
Not in a particular order, this PR:
- Revamps the ErrorOr struct so it's closer to `std::expected`
- Added documentation comments all across
- Improved varint handling, encoding and decoding
- Removed gotos
- Now Object* classes handle memory in a more safe way using smart pointers
- Converted some C-style casts into static_cast
- Simplified logic wherever possible
- Misc. things.

This builds just fine and runs as usual, I haven't experienced any stability issues, so this PR should be good.