### PR TITLE
Add more extensions to the potentially dangerous downloads list

### DIFF
--- a/src/core/utils/Util.cpp
+++ b/src/core/utils/Util.cpp
@@ -207,12 +207,22 @@ bool EndsWithCaseInsens(const std::string& what, const std::string& with)
 bool IsPotentiallyDangerousDownload(const std::string& filename)
 {
 	return
-		EndsWithCaseInsens(filename, ".exe") ||
+		EndsWithCaseInsens(filename, ".7z") ||
 		EndsWithCaseInsens(filename, ".bat") ||
-		EndsWithCaseInsens(filename, ".com") ||
-		EndsWithCaseInsens(filename, ".vbs") ||
 		EndsWithCaseInsens(filename, ".cmd") ||
-		EndsWithCaseInsens(filename, ".scr");
+		EndsWithCaseInsens(filename, ".com") ||
+		EndsWithCaseInsens(filename, ".exe") ||
+		EndsWithCaseInsens(filename, ".js") ||
+		EndsWithCaseInsens(filename, ".jse") ||
+		EndsWithCaseInsens(filename, ".hta") ||
+		EndsWithCaseInsens(filename, ".lnk") ||
+		EndsWithCaseInsens(filename, ".pif") ||
+		EndsWithCaseInsens(filename, ".rar") ||
+		EndsWithCaseInsens(filename, ".reg") ||
+		EndsWithCaseInsens(filename, ".scr") ||
+		EndsWithCaseInsens(filename, ".vbe") ||
+		EndsWithCaseInsens(filename, ".vbs") ||
+		EndsWithCaseInsens(filename, ".zip");
 }
 
 int64_t ExtractTimestamp(Snowflake sf)

--- a/src/windows/Main.cpp
+++ b/src/windows/Main.cpp
@@ -1638,18 +1638,7 @@ LRESULT CALLBACK WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 		case WM_IMAGESAVED:
 		{
 			LPCTSTR file = (LPCTSTR) lParam;
-			size_t sl = _tcslen(file);
-			bool isExe = false;
-
-			if (sl > 4 && (
-				_tcscmp(file + sl - 4, TEXT(".exe")) == 0 ||
-				_tcscmp(file + sl - 4, TEXT(".scr")) == 0 ||
-				_tcscmp(file + sl - 4, TEXT(".lnk")) == 0 ||
-				_tcscmp(file + sl - 4, TEXT(".zip")) == 0 ||
-				_tcscmp(file + sl - 4, TEXT(".rar")) == 0 ||
-				_tcscmp(file + sl - 4, TEXT(".7z"))  == 0)) {
-				isExe = true;
-			}
+			bool isExe = IsPotentiallyDangerousDownload(MakeStringFromTString(file));
 
 			TCHAR buff[4096];
 			WAsnprintf(


### PR DESCRIPTION
Replaced the filename check implementation in windows/Main.cpp to use the IsPotentiallyDangerousDownload helper, which now has every extension from both lists, and a few more, like .pif and .js.