### PR TITLE
Add focus support for notifications

### DIFF
--- a/src/core/Frontend.hpp
+++ b/src/core/Frontend.hpp
@@ -90,6 +90,7 @@ public:
 	
 	// Queries
 	virtual bool IsWindowMinimized() = 0;
+	virtual bool IsWindowFocused() = 0;
 	
 	// Strings
 	virtual std::string GetDirectMessagesText() = 0;

--- a/src/core/state/NotificationManager.cpp
+++ b/src/core/state/NotificationManager.cpp
@@ -66,8 +66,8 @@ bool NotificationManager::IsNotificationWorthy(Snowflake guildID, Snowflake chan
 		}
 	}
 
-	// If we are focused on this very channel and the window is not minimized, return
-	if (channelID == m_pDiscord->GetCurrentChannelID() && !GetFrontend()->IsWindowMinimized())
+	// If we are focused on this very channel and the window is in focus, return
+	if (channelID == m_pDiscord->GetCurrentChannelID() && GetFrontend()->IsWindowFocused())
 		return false;
 
 	auto pSettings = m_pDiscord->m_userGuildSettings.GetSettings(guildID);

--- a/src/windows/Frontend_Win32.cpp
+++ b/src/windows/Frontend_Win32.cpp
@@ -417,6 +417,11 @@ bool Frontend_Win32::IsWindowMinimized()
 	return IsIconic(g_Hwnd);
 }
 
+bool Frontend_Win32::IsWindowFocused()
+{
+	return GetForegroundWindow() == g_Hwnd;
+}
+
 #ifdef USE_DEBUG_PRINTS
 
 void DbgPrintWV(const char* fmt, va_list vl)

--- a/src/windows/Frontend_Win32.hpp
+++ b/src/windows/Frontend_Win32.hpp
@@ -63,6 +63,7 @@ public:
 	void RestoreWindow() override;
 	void MaximizeWindow() override;
 	bool IsWindowMinimized() override;
+	bool IsWindowFocused() override;
 	std::string GetDirectMessagesText() override;
 	std::string GetPleaseWaitText() override;
 	std::string GetMonthName(int index) override;


### PR DESCRIPTION
Previously the NotificationManager only checked if the window was minimised. Now, it instead checks if the window is focused.
**This has not been tested below Windows 11.**